### PR TITLE
fix not work when minimap is close

### DIFF
--- a/vscode/trailCursorEffect/index.js
+++ b/vscode/trailCursorEffect/index.js
@@ -211,7 +211,7 @@ async function createCursorHandler(handlerFunctions) {
       if (target.style.visibility != "inherit") return
 
       // if moved over minimap, ignore
-      if (minimap && minimap.getBoundingClientRect().left <= newX) return
+      if (minimap && minimap.offsetWidth != 0 && minimap.getBoundingClientRect().left <= newX) return
 
       // if cursor is not displayed on screen, ignore
       if (cursorHolder.getBoundingClientRect().left > newX) return


### PR DESCRIPTION
when user close the minimap, the `minimap.getBoundingClientRect().left` will always be `0` so that the trailCursor not work.

just add a check for whether minimap is closed by using `minimap.offsetWidth != 0`